### PR TITLE
Vorschlag zur Fehlerbehebung in Extensions.Logging

### DIFF
--- a/libraries/JGUZDV.Extensions.Logging/src/JGUZDV.Extensions.Logging.csproj
+++ b/libraries/JGUZDV.Extensions.Logging/src/JGUZDV.Extensions.Logging.csproj
@@ -7,7 +7,7 @@
 
 		<PackageId>JGUZDV.Extensions.Logging</PackageId>
 		<IsPackable>true</IsPackable>
-		<Version>1.2.5</Version>
+		<Version>1.2.6</Version>
 		<Authors>Thomas Ottenhus</Authors>
 		<Company>Zentrum für Datenverarbeitung - JGU Mainz</Company>
 		<PackageDescription>Adds file logging via IHostBuilder.</PackageDescription>

--- a/libraries/JGUZDV.Extensions.Logging/src/JGUZDVHostBuilderLoggingExtensions.cs
+++ b/libraries/JGUZDV.Extensions.Logging/src/JGUZDVHostBuilderLoggingExtensions.cs
@@ -13,33 +13,27 @@ namespace Microsoft.Extensions.DependencyInjection;
 public static class JGUZDVHostBuilderLoggingExtensions
 {
     /// <summary>
-    /// Configures the host builder to use the default logging configuration.
-    /// </summary>
-    public static IHostBuilder UseJGUZDVLogging(this IHostBuilder hostBuilder)
-        => hostBuilder.UseJGUZDVLogging();
-
-    /// <summary>
     /// Configures the host builder to use the specified logging configuration.
     /// </summary>
     public static IHostBuilder UseJGUZDVLogging(this IHostBuilder hostBuilder, bool useJsonFormat = true)
     {
+        if (useJsonFormat)
+        {
+            hostBuilder.ConfigureLogging((hostBuilderContext, loggingBuilder) =>
+            {
+                loggingBuilder.AddJsonFile();
+            });
+        }
+        else
+        {
+            hostBuilder.ConfigureLogging((hostBuilderContext, loggingBuilder) =>
+            {
+                loggingBuilder.AddPlainTextFile();
+            });
+        }
+
         hostBuilder.ConfigureServices((hostContext, services) =>
         {
-            if (useJsonFormat)
-            {
-                hostBuilder.ConfigureLogging((hostBuilderContext, loggingBuilder) =>
-                {
-                    loggingBuilder.AddJsonFile();
-                });
-            }
-            else
-            {
-                hostBuilder.ConfigureLogging((hostBuilderContext, loggingBuilder) =>
-                {
-                    loggingBuilder.AddPlainTextFile();
-                });
-            }
-
             services.PostConfigure<FileLoggerOptions>(configureOptions =>
             {
                 if (string.IsNullOrWhiteSpace(configureOptions.OutputDirectory))
@@ -51,7 +45,7 @@ public static class JGUZDVHostBuilderLoggingExtensions
                 // Add the application name to the output directory, so log files for
                 // different apps will be written to different directories.
                 configureOptions.OutputDirectory = Path.Combine(
-                    configureOptions.OutputDirectory, 
+                    configureOptions.OutputDirectory,
                     hostContext.HostingEnvironment.ApplicationName);
             });
         });

--- a/libraries/JGUZDV.Extensions.Logging/test/Tests.cs
+++ b/libraries/JGUZDV.Extensions.Logging/test/Tests.cs
@@ -11,8 +11,6 @@ public class Tests
     [Fact]
     public void TestLoggingConfig()
     {
-        /* TODO Check this test. Leads to exception Collection was modified; enumeration operation may not execute.
-        
         var builder = Host.CreateDefaultBuilder();
         builder.ConfigureAppConfiguration(c => c
             .AddJsonFile("appsettings.test.json", optional: false)
@@ -27,6 +25,5 @@ public class Tests
         var logger = app.Services.GetRequiredService<ILogger<Tests>>();
         logger.LogWarning("Warning!");
         logger.LogError("Error!");
-        */
     }
 }

--- a/libraries/JGUZDV.Extensions.Logging/test/appsettings.test.json
+++ b/libraries/JGUZDV.Extensions.Logging/test/appsettings.test.json
@@ -12,7 +12,7 @@
     },
 
     "File": {
-      "OutputDirectory": "C:\\Temp\\FileLogger",
+      "OutputDirectory": ".\\Temp\\FileLogger",
       "LogLevel": {
         "Default": "Error"
       }


### PR DESCRIPTION
Hab die Registrierung des Loggers aus der 'ConfigureServices' Methode rausgenommen was dazu geführt hat dass der 'Colletion was modified' Fehler nicht mehr auftritt und in 'JGUZDVHostBuilderLoggingExtensions' den redundanten aufruf von 'UseJGUZDVLogging' entfernt da dieser zu einem rekursiven aufruf von sich selbst und somit zu einem Laufzeitfehler führte. 

Außerdem habe ich den Pfad für die Test-Loggerdatei geändert da 'C:\Temp' schreibgeschützt ist und somit zu einem weiteren Fehler beim Testen geführt hat. 

Zuletzt habe ich den Test wieder auskomentiert und er läuft durch.