### PR TITLE
Optional telemetry configuration

### DIFF
--- a/libraries/JGUZDV.Extensions.OpenTelemetry/src/JGUZDVBaseMeter.cs
+++ b/libraries/JGUZDV.Extensions.OpenTelemetry/src/JGUZDVBaseMeter.cs
@@ -27,7 +27,14 @@ public abstract class JGUZDVBaseMeter
     {
         _telemetryOptions = options;
 
-        Meter = new Meter(_telemetryOptions.Value.Metrics!.MeterName, options.Value.Metrics!.MeterVersion);
+        if (_telemetryOptions.Value.UseMeter == null)
+            throw new ArgumentException("Can only be used if UseMeter is completly configured in appsettings.");
+
+        if (string.IsNullOrWhiteSpace(_telemetryOptions.Value.UseMeter.MeterName)
+                || string.IsNullOrWhiteSpace(_telemetryOptions.Value.UseMeter.MeterVersion))
+            throw new ArgumentException("MeterName and MeterVersion must be set to reasonable values.");
+
+        Meter = new Meter(_telemetryOptions.Value.UseMeter.MeterName, _telemetryOptions.Value.UseMeter.MeterVersion);
     }
 }
 

--- a/libraries/JGUZDV.Extensions.OpenTelemetry/src/JGUZDVOpenTelemetryOptions.cs
+++ b/libraries/JGUZDV.Extensions.OpenTelemetry/src/JGUZDVOpenTelemetryOptions.cs
@@ -21,9 +21,9 @@ public class JGUZDVOpenTelemetryOptions
     public string? ServiceName { get; set; } = default!;
 
     /// <summary>
-    /// Mandatory. Configures a basic env for metrics and creates a basic meter instance.
+    /// Optional. Configures a basic env for metrics and creates a basic meter instance.
     /// </summary>
-    public OpenTelemetryMetricsOptions? Metrics { get; set; } = default!;
+    public OpenTelemetryUseMeterOptions? UseMeter { get; set; } = default!;
 }
 
 /// <summary>
@@ -38,11 +38,11 @@ public class OpenTelemetryAzureMonitorOptions
 }
 
 /// <summary>
-/// Mandatory. Metrics options to configure a Meter. A Meter is used to directly transfer
+/// Optional. UseMeter options to configure a Meter. A Meter is used to directly transfer
 /// telemetry - like statistics, volume data or quantity structures.
-/// All inner properties are mandatory as well.
+/// If defined, all inner properties are mandatory.
 /// </summary>
-public class OpenTelemetryMetricsOptions
+public class OpenTelemetryUseMeterOptions
 {
     /// <summary>
     /// The name of the meter that will be added.

--- a/libraries/JGUZDV.Extensions.OpenTelemetry/src/README.md
+++ b/libraries/JGUZDV.Extensions.OpenTelemetry/src/README.md
@@ -21,7 +21,8 @@ Host.CreateApplicationBuilder()
 
 ## Configuration
 
-These required configuration settings should be configured in your appsettings.json using the follwing example:
+Basic configuration settings to initialize the services should be configured as 
+in the following example in your appsettings (root level):
 
 ~~~ JSON
   ...
@@ -39,15 +40,18 @@ These required configuration settings should be configured in your appsettings.j
   ...
 ~~~
 
-**Explanation:** Since this Extension is primarily aimed at ETL processes, for which sending metrics is essential, the "OpenTelemetry" section as well as all the parameters are required.
-ServiceNamespace should describe a summarizing border or boundary, and ServiceName should be the concrete and unique name of the application. 
+**Explanation:** If no "OpenTelemetry" section can be found, nothing will happen at all. 
+If such a section is present, the included parameters will be checked.
+ConnectionString is obviously a mandatory config parameter. 
+WebAppNamespace should describe a summarizing border or boundary, and WebAppName should be the concrete and unique name of the WebApp. 
 The name and namespace parameters should be about 10 to 15 characters, the strings should not include any whitespace or special characters.
+The section "UseMeter" is optional, but if it is present, the two inner fields are mandatory.
 
 ## Meter
 
-Since configuring a meter is required, this section details how to implement the necessary services to report metrics.
+If you wish to send metrics for your application follow these steps:
 
-**Steps:**
+- Configure "OpenTelemetry:UseMetrics" section in **appsettings.json**
 - Implement a service inheriting from JGUZDVBaseMeter
 - Add the service to the service container as singleton
 


### PR DESCRIPTION
Applications no longer crash if "OpenTelemetry" section is missing. Instead we check if the section is present and act accordingly.