### PR TITLE
New minor version for job host packages.

### DIFF
--- a/libraries/JGUZDV.JobHost/Directory.Build.props
+++ b/libraries/JGUZDV.JobHost/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>1.2.2</Version>
+        <Version>1.2.3</Version>
     </PropertyGroup>
 
     <ImportGroup>


### PR DESCRIPTION
Reason is a dependency update for JGUZDV.Extensions.OpenTelemetry / Azure.Monitor.OpenTelemetry.Exporter.